### PR TITLE
pptrecord: Decode UTF-8 string to get correct number of characters stored in TextCharsAtom/TextBytesAtom

### DIFF
--- a/msodumper/pptrecord.py
+++ b/msodumper/pptrecord.py
@@ -788,7 +788,7 @@ class TextStyles(BaseRecordHandler):
             self.appendLine("no shape text given, assuming length of 1")
             textLen = 1
         else:
-            textLen = len(self.streamProperties["ShapeText"])
+            textLen = len(self.streamProperties["ShapeText"].decode("UTF-8"))
 
         # 4 bytes: <count> characters of shape text this para run is meant for
         # <para attribs>


### PR DESCRIPTION
The correct number of characters is required to properly parse the StyleTextPropAtom.  It contains arrays of TextPFRun and TextCFRun structures and the number of elements is defined by the number of text runs which fit into the text length.
