### PR TITLE
Fix LabelRecord row & col properties

### DIFF
--- a/msodumper/xlsrecord.py
+++ b/msodumper/xlsrecord.py
@@ -1326,8 +1326,8 @@ class Array(BaseRecordHandler):
 class Label(BaseRecordHandler):
 
     def __parseBytes (self):
-        self.col = self.readUnsignedInt(2)
         self.row = self.readUnsignedInt(2)
+        self.col = self.readUnsignedInt(2)
         self.xfIdx = self.readUnsignedInt(2)
         textLen = self.readUnsignedInt(2)
         self.text, textLen = globals.getRichText(self.readRemainingBytes(), textLen)


### PR DESCRIPTION
The first 2 bits is row index, not a col index.
See 5.63 more in http://www.openoffice.org/sc/excelfileformat.pdf.